### PR TITLE
Workaround for batch correcting SCT Transformed data

### DIFF
--- a/R/02_seu_batch_correct.R
+++ b/R/02_seu_batch_correct.R
@@ -422,6 +422,19 @@ batch_correct_seurat <- function(
     markers <- rownames(object)
   }
 
+  if(DefaultAssay(object) == "SCT"){
+    ## Workaround for correctly subsetting SCT assays.
+    ## Published on github by longmanz
+    ## https://github.com/satijalab/seurat-object/issues/208
+    
+    tmp_SCT_features_attributes = slot(object = object[['SCT']], name = "SCTModel.list")[[1]]@feature.attributes 
+    tmp_SCT_features_attributes = tmp_SCT_features_attributes[markers, ]
+    slot(object = object[['SCT']], name = "SCTModel.list")[[1]]@feature.attributes = tmp_SCT_features_attributes
+    object <- subset(object, features = markers)
+  }else{
+    object <- object[markers, ]
+  }
+  
   object <- object[markers, ]
 
   for (i in seq_len(max(length(xdim), length(ydim)))) {

--- a/R/02_seu_batch_correct.R
+++ b/R/02_seu_batch_correct.R
@@ -434,8 +434,6 @@ batch_correct_seurat <- function(
   }else{
     object <- object[markers, ]
   }
-  
-  object <- object[markers, ]
 
   for (i in seq_len(max(length(xdim), length(ydim)))) {
     xdim_i <- xdim[min(length(xdim), i)]


### PR DESCRIPTION
In the batch_correct_seurat function of the 02_seu_batch_correct.R script I have changed the following:
I have included a workaround for subsetting SCT Transformed data in cases where the DefaultAssay is SCT, as the current version of Seurat does not support the bracket-style subsetting of SCT models. This allows the batch correct function to run on the SCT data type.

The workaround for subsetting was initially proposed by 'longmanz' in relation to issue 208 of the Seurat_object GitHub. (https://github.com/satijalab/seurat-object/issues/208).
